### PR TITLE
feat(test): add comprehensive unit tests (Mockito) and API tests (Kar…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,36 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.karatelabs</groupId>
+			<artifactId>karate-junit5</artifactId>
+			<version>1.5.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals><goal>prepare-agent</goal></goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals><goal>report</goal></goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/src/test/java/com/github/camiloperez77/trackingservice/application/listeners/ShipmentCreatedListenerTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/application/listeners/ShipmentCreatedListenerTest.java
@@ -1,0 +1,50 @@
+package com.github.camiloperez77.trackingservice.application.listeners;
+
+import com.github.camiloperez77.trackingservice.domain.ports.in.TrackingUseCase;
+import com.github.camiloperez77.trackingservice.infrastructure.messaging.dto.ShipmentCreatedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ShipmentCreatedListenerTest {
+
+    @Mock
+    private TrackingUseCase trackingUseCase;
+
+    @InjectMocks
+    private ShipmentCreatedListener listener;
+
+    @Test
+    @DisplayName("Receives ShipmentCreatedEvent and calls initializeShipment with correct args")
+    void handleShipmentCreated_shouldCallInitializeShipment() {
+        UUID shipmentId = UUID.randomUUID();
+        String trackingId = "TRK-001";
+
+        ShipmentCreatedEvent event = new ShipmentCreatedEvent(shipmentId, trackingId, "Sender", "Recipient");
+
+        listener.handleShipmentCreated(event);
+
+        verify(trackingUseCase).initializeShipment(shipmentId, trackingId);
+    }
+
+    @Test
+    @DisplayName("Handles UUID parsing correctly with different UUID formats")
+    void handleShipmentCreated_shouldHandleUUIDCorrectly() {
+        UUID shipmentId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        String trackingId = "TRK-UUID-TEST";
+
+        ShipmentCreatedEvent event = new ShipmentCreatedEvent(shipmentId, trackingId, "Sender", "Recipient");
+
+        listener.handleShipmentCreated(event);
+
+        verify(trackingUseCase).initializeShipment(shipmentId, trackingId);
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/application/listeners/TrackingEventRequestListenerTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/application/listeners/TrackingEventRequestListenerTest.java
@@ -1,0 +1,58 @@
+package com.github.camiloperez77.trackingservice.application.listeners;
+
+import com.github.camiloperez77.trackingservice.domain.ports.in.TrackingUseCase;
+import com.github.camiloperez77.trackingservice.infrastructure.messaging.dto.TrackingEventRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TrackingEventRequestListenerTest {
+
+    @Mock
+    private TrackingUseCase trackingUseCase;
+
+    @InjectMocks
+    private TrackingEventRequestListener listener;
+
+    @Test
+    @DisplayName("Receives TrackingEventRequest and calls registerEvent with correct args")
+    void handleTrackingEventRequest_shouldCallRegisterEvent() {
+        UUID shipmentId = UUID.randomUUID();
+        String eventType = "DISPATCHED";
+        String location = "Hub Central";
+        LocalDateTime occurredAt = LocalDateTime.now();
+
+        TrackingEventRequest request = new TrackingEventRequest(shipmentId, eventType, location, occurredAt);
+
+        listener.handleTrackingEventRequest(request);
+
+        verify(trackingUseCase).registerEvent(shipmentId, eventType, location, occurredAt);
+    }
+
+    @Test
+    @DisplayName("Propagates exceptions wrapped in IllegalStateException for dead-letter queue handling")
+    void handleTrackingEventRequest_shouldPropagateExceptions() {
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime occurredAt = LocalDateTime.now();
+
+        TrackingEventRequest request = new TrackingEventRequest(shipmentId, "DISPATCHED", "Hub", occurredAt);
+
+        when(trackingUseCase.registerEvent(shipmentId, "DISPATCHED", "Hub", occurredAt))
+                .thenThrow(new IllegalArgumentException("Shipment not found"));
+
+        assertThatThrownBy(() -> listener.handleTrackingEventRequest(request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to process tracking event request")
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/application/rest/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/application/rest/GlobalExceptionHandlerTest.java
@@ -1,0 +1,59 @@
+package com.github.camiloperez77.trackingservice.application.rest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @RestController
+    static class FakeController {
+
+        @GetMapping("/fake/not-found")
+        public void throwIllegalArgument() {
+            throw new IllegalArgumentException("Shipment not found with id: abc-123");
+        }
+
+        @GetMapping("/fake/conflict")
+        public void throwIllegalState() {
+            throw new IllegalStateException("Invalid status transition from CREATED to DELIVERED");
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new FakeController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("IllegalArgumentException returns 404 NOT_FOUND")
+    void handleIllegalArgument_returns404() throws Exception {
+        mockMvc.perform(get("/fake/not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Shipment not found with id: abc-123"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DisplayName("IllegalStateException returns 409 CONFLICT")
+    void handleIllegalState_returns409() throws Exception {
+        mockMvc.perform(get("/fake/conflict"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"))
+                .andExpect(jsonPath("$.message").value("Invalid status transition from CREATED to DELIVERED"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/application/rest/TrackingControllerTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/application/rest/TrackingControllerTest.java
@@ -1,0 +1,136 @@
+package com.github.camiloperez77.trackingservice.application.rest;
+
+import com.github.camiloperez77.trackingservice.domain.model.Shipment;
+import com.github.camiloperez77.trackingservice.domain.model.ShipmentStatus;
+import com.github.camiloperez77.trackingservice.domain.model.TrackingEvent;
+import com.github.camiloperez77.trackingservice.domain.ports.in.TrackingUseCase;
+import com.github.camiloperez77.trackingservice.infrastructure.messaging.config.RabbitMQConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import org.springframework.amqp.core.MessagePostProcessor;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class TrackingControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private TrackingUseCase trackingUseCase;
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private TrackingController trackingController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(trackingController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST /{shipmentId}/events returns 202 Accepted with X-Correlation-Id header")
+    void registerEvent_shouldReturn202WithCorrelationId() throws Exception {
+        UUID shipmentId = UUID.randomUUID();
+
+        mockMvc.perform(post("/api/v1/tracking/{shipmentId}/events", shipmentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "eventType": "DISPATCHED",
+                                    "location": "Hub Central",
+                                    "occurredAt": "2026-04-07T10:00:00"
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(header().exists("X-Correlation-Id"));
+
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.LOGISTICS_EXCHANGE),
+                eq("tracking.event.request"),
+                any(Object.class),
+                any(MessagePostProcessor.class)
+        );
+    }
+
+    @Test
+    @DisplayName("GET /{shipmentId}/history returns 200 with event list")
+    void getHistory_shouldReturn200WithEvents() throws Exception {
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime occurredAt = LocalDateTime.of(2026, 4, 7, 10, 0, 0);
+
+        TrackingEvent event = new TrackingEvent(
+                UUID.randomUUID(), shipmentId, "DISPATCHED",
+                ShipmentStatus.CREATED, ShipmentStatus.IN_TRANSIT,
+                "Hub Central", occurredAt, LocalDateTime.now()
+        );
+
+        when(trackingUseCase.getHistory(shipmentId)).thenReturn(List.of(event));
+
+        mockMvc.perform(get("/api/v1/tracking/{shipmentId}/history", shipmentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].eventType").value("DISPATCHED"))
+                .andExpect(jsonPath("$[0].statusBefore").value("CREATED"))
+                .andExpect(jsonPath("$[0].statusAfter").value("IN_TRANSIT"))
+                .andExpect(jsonPath("$[0].location").value("Hub Central"));
+    }
+
+    @Test
+    @DisplayName("GET /{shipmentId}/history returns 404 when shipment not found")
+    void getHistory_shipmentNotFound_shouldReturn404() throws Exception {
+        UUID shipmentId = UUID.randomUUID();
+        when(trackingUseCase.getHistory(shipmentId))
+                .thenThrow(new IllegalArgumentException("Shipment not found with id: " + shipmentId));
+
+        mockMvc.perform(get("/api/v1/tracking/{shipmentId}/history", shipmentId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("GET /{shipmentId}/current returns 200 with status")
+    void getCurrentStatus_shouldReturn200WithStatus() throws Exception {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.IN_TRANSIT);
+        when(trackingUseCase.getCurrentStatus(shipmentId)).thenReturn(shipment);
+
+        mockMvc.perform(get("/api/v1/tracking/{shipmentId}/current", shipmentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("IN_TRANSIT"));
+    }
+
+    @Test
+    @DisplayName("GET /{shipmentId}/current returns 404 when shipment not found")
+    void getCurrentStatus_shipmentNotFound_shouldReturn404() throws Exception {
+        UUID shipmentId = UUID.randomUUID();
+        when(trackingUseCase.getCurrentStatus(shipmentId))
+                .thenThrow(new IllegalArgumentException("Shipment not found with id: " + shipmentId));
+
+        mockMvc.perform(get("/api/v1/tracking/{shipmentId}/current", shipmentId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/domain/model/ShipmentStatusTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/domain/model/ShipmentStatusTest.java
@@ -1,0 +1,147 @@
+package com.github.camiloperez77.trackingservice.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShipmentStatusTest {
+
+    @Nested
+    @DisplayName("CREATED transitions")
+    class CreatedTransitions {
+
+        @Test
+        @DisplayName("CREATED -> IN_TRANSIT is valid")
+        void createdToInTransit_shouldBeValid() {
+            assertThat(ShipmentStatus.CREATED.canTransitionTo(ShipmentStatus.IN_TRANSIT)).isTrue();
+        }
+
+        @Test
+        @DisplayName("CP-04-02: CREATED -> DELIVERED is invalid")
+        void createdToDelivered_shouldBeInvalid() {
+            assertThat(ShipmentStatus.CREATED.canTransitionTo(ShipmentStatus.DELIVERED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("CREATED -> OUT_FOR_DELIVERY is invalid")
+        void createdToOutForDelivery_shouldBeInvalid() {
+            assertThat(ShipmentStatus.CREATED.canTransitionTo(ShipmentStatus.OUT_FOR_DELIVERY)).isFalse();
+        }
+
+        @Test
+        @DisplayName("CREATED -> EXCEPTION is invalid")
+        void createdToException_shouldBeInvalid() {
+            assertThat(ShipmentStatus.CREATED.canTransitionTo(ShipmentStatus.EXCEPTION)).isFalse();
+        }
+
+        @Test
+        @DisplayName("CREATED -> CREATED is invalid")
+        void createdToCreated_shouldBeInvalid() {
+            assertThat(ShipmentStatus.CREATED.canTransitionTo(ShipmentStatus.CREATED)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("IN_TRANSIT transitions")
+    class InTransitTransitions {
+
+        @Test
+        @DisplayName("IN_TRANSIT -> OUT_FOR_DELIVERY is valid")
+        void inTransitToOutForDelivery_shouldBeValid() {
+            assertThat(ShipmentStatus.IN_TRANSIT.canTransitionTo(ShipmentStatus.OUT_FOR_DELIVERY)).isTrue();
+        }
+
+        @Test
+        @DisplayName("IN_TRANSIT -> EXCEPTION is valid")
+        void inTransitToException_shouldBeValid() {
+            assertThat(ShipmentStatus.IN_TRANSIT.canTransitionTo(ShipmentStatus.EXCEPTION)).isTrue();
+        }
+
+        @Test
+        @DisplayName("IN_TRANSIT -> DELIVERED is invalid")
+        void inTransitToDelivered_shouldBeInvalid() {
+            assertThat(ShipmentStatus.IN_TRANSIT.canTransitionTo(ShipmentStatus.DELIVERED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("IN_TRANSIT -> CREATED is invalid")
+        void inTransitToCreated_shouldBeInvalid() {
+            assertThat(ShipmentStatus.IN_TRANSIT.canTransitionTo(ShipmentStatus.CREATED)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("OUT_FOR_DELIVERY transitions")
+    class OutForDeliveryTransitions {
+
+        @Test
+        @DisplayName("OUT_FOR_DELIVERY -> DELIVERED is valid")
+        void outForDeliveryToDelivered_shouldBeValid() {
+            assertThat(ShipmentStatus.OUT_FOR_DELIVERY.canTransitionTo(ShipmentStatus.DELIVERED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("OUT_FOR_DELIVERY -> EXCEPTION is valid")
+        void outForDeliveryToException_shouldBeValid() {
+            assertThat(ShipmentStatus.OUT_FOR_DELIVERY.canTransitionTo(ShipmentStatus.EXCEPTION)).isTrue();
+        }
+
+        @Test
+        @DisplayName("OUT_FOR_DELIVERY -> IN_TRANSIT is invalid")
+        void outForDeliveryToInTransit_shouldBeInvalid() {
+            assertThat(ShipmentStatus.OUT_FOR_DELIVERY.canTransitionTo(ShipmentStatus.IN_TRANSIT)).isFalse();
+        }
+
+        @Test
+        @DisplayName("OUT_FOR_DELIVERY -> CREATED is invalid")
+        void outForDeliveryToCreated_shouldBeInvalid() {
+            assertThat(ShipmentStatus.OUT_FOR_DELIVERY.canTransitionTo(ShipmentStatus.CREATED)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("DELIVERED transitions (terminal state)")
+    class DeliveredTransitions {
+
+        @Test
+        @DisplayName("DELIVERED -> any is invalid (terminal state)")
+        void delivered_shouldNotTransitionToAnyState() {
+            for (ShipmentStatus status : ShipmentStatus.values()) {
+                assertThat(ShipmentStatus.DELIVERED.canTransitionTo(status))
+                        .as("DELIVERED -> %s should be invalid", status)
+                        .isFalse();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("EXCEPTION transitions (recovery)")
+    class ExceptionTransitions {
+
+        @Test
+        @DisplayName("EXCEPTION -> IN_TRANSIT is valid (recovery)")
+        void exceptionToInTransit_shouldBeValid() {
+            assertThat(ShipmentStatus.EXCEPTION.canTransitionTo(ShipmentStatus.IN_TRANSIT)).isTrue();
+        }
+
+        @Test
+        @DisplayName("EXCEPTION -> CREATED is valid")
+        void exceptionToCreated_shouldBeValid() {
+            assertThat(ShipmentStatus.EXCEPTION.canTransitionTo(ShipmentStatus.CREATED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("EXCEPTION -> DELIVERED is invalid")
+        void exceptionToDelivered_shouldBeInvalid() {
+            assertThat(ShipmentStatus.EXCEPTION.canTransitionTo(ShipmentStatus.DELIVERED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("EXCEPTION -> OUT_FOR_DELIVERY is invalid")
+        void exceptionToOutForDelivery_shouldBeInvalid() {
+            assertThat(ShipmentStatus.EXCEPTION.canTransitionTo(ShipmentStatus.OUT_FOR_DELIVERY)).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/domain/model/ShipmentTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/domain/model/ShipmentTest.java
@@ -1,0 +1,73 @@
+package com.github.camiloperez77.trackingservice.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ShipmentTest {
+
+    @Test
+    @DisplayName("updateStatus with valid transition changes status")
+    void updateStatus_validTransition_shouldChangeStatus() {
+        Shipment shipment = new Shipment(UUID.randomUUID(), "TRK-001", ShipmentStatus.CREATED);
+
+        shipment.updateStatus(ShipmentStatus.IN_TRANSIT);
+
+        assertThat(shipment.getStatus()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+    }
+
+    @Test
+    @DisplayName("updateStatus with invalid transition throws IllegalStateException")
+    void updateStatus_invalidTransition_shouldThrowIllegalStateException() {
+        Shipment shipment = new Shipment(UUID.randomUUID(), "TRK-001", ShipmentStatus.CREATED);
+
+        assertThatThrownBy(() -> shipment.updateStatus(ShipmentStatus.DELIVERED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Invalid status transition from CREATED to DELIVERED");
+    }
+
+    @Test
+    @DisplayName("updateStatus updates the updatedAt timestamp")
+    void updateStatus_shouldUpdateTimestamp() {
+        LocalDateTime beforeUpdate = LocalDateTime.now().minusSeconds(1);
+        Shipment shipment = new Shipment(UUID.randomUUID(), "TRK-001", ShipmentStatus.CREATED,
+                LocalDateTime.now().minusHours(1), LocalDateTime.now().minusHours(1));
+
+        LocalDateTime originalUpdatedAt = shipment.getUpdatedAt();
+
+        shipment.updateStatus(ShipmentStatus.IN_TRANSIT);
+
+        assertThat(shipment.getUpdatedAt()).isAfter(originalUpdatedAt);
+        assertThat(shipment.getUpdatedAt()).isAfter(beforeUpdate);
+    }
+
+    @Test
+    @DisplayName("Constructor sets all fields correctly")
+    void constructor_shouldSetAllFields() {
+        UUID id = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+
+        Shipment shipment = new Shipment(id, "TRK-002", ShipmentStatus.IN_TRANSIT, now, now);
+
+        assertThat(shipment.getId()).isEqualTo(id);
+        assertThat(shipment.getTrackingId()).isEqualTo("TRK-002");
+        assertThat(shipment.getStatus()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+        assertThat(shipment.getCreatedAt()).isEqualTo(now);
+        assertThat(shipment.getUpdatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("DELIVERED is a terminal state - cannot transition further")
+    void updateStatus_fromDelivered_shouldThrow() {
+        Shipment shipment = new Shipment(UUID.randomUUID(), "TRK-001", ShipmentStatus.DELIVERED,
+                LocalDateTime.now(), LocalDateTime.now());
+
+        assertThatThrownBy(() -> shipment.updateStatus(ShipmentStatus.CREATED))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/domain/service/TrackingServiceTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/domain/service/TrackingServiceTest.java
@@ -1,0 +1,350 @@
+package com.github.camiloperez77.trackingservice.domain.service;
+
+import com.github.camiloperez77.trackingservice.domain.model.Shipment;
+import com.github.camiloperez77.trackingservice.domain.model.ShipmentStatus;
+import com.github.camiloperez77.trackingservice.domain.model.TrackingEvent;
+import com.github.camiloperez77.trackingservice.domain.model.TrackingEventNotification;
+import com.github.camiloperez77.trackingservice.domain.ports.out.EventPublisherPort;
+import com.github.camiloperez77.trackingservice.domain.ports.out.ShipmentRepositoryPort;
+import com.github.camiloperez77.trackingservice.domain.ports.out.TrackingEventRepositoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TrackingServiceTest {
+
+    @Mock
+    private ShipmentRepositoryPort shipmentRepository;
+
+    @Mock
+    private TrackingEventRepositoryPort eventRepository;
+
+    @Mock
+    private EventPublisherPort eventPublisher;
+
+    @InjectMocks
+    private TrackingService trackingService;
+
+    @Test
+    @DisplayName("registerEvent with valid transition creates event and updates shipment")
+    void registerEvent_validTransition_createsEventAndUpdatesShipment() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.CREATED);
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+        when(eventRepository.save(any(TrackingEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(shipmentRepository.save(any(Shipment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        LocalDateTime occurredAt = LocalDateTime.now();
+        TrackingEvent result = trackingService.registerEvent(shipmentId, "DISPATCHED", "Hub Central", occurredAt);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getShipmentId()).isEqualTo(shipmentId);
+        assertThat(result.getEventType()).isEqualTo("DISPATCHED");
+        assertThat(result.getStatusBefore()).isEqualTo(ShipmentStatus.CREATED);
+        assertThat(result.getStatusAfter()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+        assertThat(result.getLocation()).isEqualTo("Hub Central");
+
+        verify(eventRepository).save(any(TrackingEvent.class));
+        verify(shipmentRepository).save(shipment);
+    }
+
+    @Test
+    @DisplayName("CP-04-02: registerEvent with invalid transition throws IllegalStateException")
+    void registerEvent_invalidTransition_throwsIllegalState() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.CREATED);
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+
+        assertThatThrownBy(() ->
+                trackingService.registerEvent(shipmentId, "DELIVERED", "Warehouse", LocalDateTime.now())
+        ).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Invalid status transition");
+    }
+
+    @Test
+    @DisplayName("registerEvent with shipment not found throws IllegalArgumentException")
+    void registerEvent_shipmentNotFound_throwsIllegalArgument() {
+        UUID shipmentId = UUID.randomUUID();
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                trackingService.registerEvent(shipmentId, "DISPATCHED", "Hub", LocalDateTime.now())
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Shipment not found");
+    }
+
+    @Test
+    @DisplayName("registerEvent publishes notification")
+    void registerEvent_publishesNotification() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.CREATED);
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+        when(eventRepository.save(any(TrackingEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(shipmentRepository.save(any(Shipment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        LocalDateTime occurredAt = LocalDateTime.now();
+        trackingService.registerEvent(shipmentId, "DISPATCHED", "Hub Central", occurredAt);
+
+        ArgumentCaptor<TrackingEventNotification> captor = ArgumentCaptor.forClass(TrackingEventNotification.class);
+        verify(eventPublisher).publishTrackingEventRecorded(captor.capture());
+
+        TrackingEventNotification notification = captor.getValue();
+        assertThat(notification.shipmentId()).isEqualTo(shipmentId);
+        assertThat(notification.trackingId()).isEqualTo("TRK-001");
+        assertThat(notification.eventType()).isEqualTo("DISPATCHED");
+        assertThat(notification.previousStatus()).isEqualTo("CREATED");
+        assertThat(notification.newStatus()).isEqualTo("IN_TRANSIT");
+        assertThat(notification.occurredAt()).isEqualTo(occurredAt);
+    }
+
+    @Test
+    @DisplayName("CP-04-01: registerEvent DISPATCHED maps to IN_TRANSIT")
+    void registerEvent_DISPATCHED_mapsToIN_TRANSIT() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.CREATED);
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+        when(eventRepository.save(any(TrackingEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(shipmentRepository.save(any(Shipment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        TrackingEvent result = trackingService.registerEvent(shipmentId, "DISPATCHED", "Hub", LocalDateTime.now());
+
+        assertThat(result.getStatusAfter()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+    }
+
+    @Test
+    @DisplayName("registerEvent DELIVERED maps to DELIVERED")
+    void registerEvent_DELIVERED_mapsToDELIVERED() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.OUT_FOR_DELIVERY,
+                LocalDateTime.now(), LocalDateTime.now());
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+        when(eventRepository.save(any(TrackingEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(shipmentRepository.save(any(Shipment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        TrackingEvent result = trackingService.registerEvent(shipmentId, "DELIVERED", "Destination", LocalDateTime.now());
+
+        assertThat(result.getStatusAfter()).isEqualTo(ShipmentStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("registerEvent unknown event type maps to EXCEPTION")
+    void registerEvent_unknownEventType_mapsToEXCEPTION() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.IN_TRANSIT,
+                LocalDateTime.now(), LocalDateTime.now());
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+        when(eventRepository.save(any(TrackingEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(shipmentRepository.save(any(Shipment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        TrackingEvent result = trackingService.registerEvent(shipmentId, "UNKNOWN_TYPE", "Somewhere", LocalDateTime.now());
+
+        assertThat(result.getStatusAfter()).isEqualTo(ShipmentStatus.EXCEPTION);
+    }
+
+    @Test
+    @DisplayName("getHistory returns ordered events")
+    void getHistory_returnsOrderedEvents() {
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime time1 = LocalDateTime.now().minusHours(2);
+        LocalDateTime time2 = LocalDateTime.now().minusHours(1);
+        TrackingEvent event1 = new TrackingEvent(UUID.randomUUID(), shipmentId, "DISPATCHED",
+                ShipmentStatus.CREATED, ShipmentStatus.IN_TRANSIT, "Hub A", time1);
+        TrackingEvent event2 = new TrackingEvent(UUID.randomUUID(), shipmentId, "OUT_FOR_DELIVERY",
+                ShipmentStatus.IN_TRANSIT, ShipmentStatus.OUT_FOR_DELIVERY, "Hub B", time2);
+
+        when(eventRepository.findByShipmentIdOrderByOccurredAtAsc(shipmentId))
+                .thenReturn(List.of(event1, event2));
+
+        List<TrackingEvent> history = trackingService.getHistory(shipmentId);
+
+        assertThat(history).hasSize(2);
+        assertThat(history.get(0).getOccurredAt()).isBefore(history.get(1).getOccurredAt());
+    }
+
+    @Test
+    @DisplayName("getHistory for non-existent shipment returns empty list (delegated to repository)")
+    void getHistory_shipmentNotFound_returnsEmptyList() {
+        UUID shipmentId = UUID.randomUUID();
+        when(eventRepository.findByShipmentIdOrderByOccurredAtAsc(shipmentId))
+                .thenReturn(List.of());
+
+        List<TrackingEvent> history = trackingService.getHistory(shipmentId);
+
+        assertThat(history).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getCurrentStatus returns shipment")
+    void getCurrentStatus_returnsShipment() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.IN_TRANSIT);
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+
+        Shipment result = trackingService.getCurrentStatus(shipmentId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(shipmentId);
+        assertThat(result.getStatus()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+    }
+
+    @Test
+    @DisplayName("getCurrentStatus shipment not found throws IllegalArgumentException")
+    void getCurrentStatus_shipmentNotFound_throwsIllegalArgument() {
+        UUID shipmentId = UUID.randomUUID();
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> trackingService.getCurrentStatus(shipmentId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Shipment not found");
+    }
+
+    // --- initializeShipment tests ---
+
+    @Test
+    @DisplayName("initializeShipment creates new shipment when none exists")
+    void initializeShipment_newShipment_savesSuccessfully() {
+        UUID shipmentId = UUID.randomUUID();
+        String trackingId = "TRK-NEW";
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.empty());
+        when(shipmentRepository.findByTrackingId(trackingId)).thenReturn(Optional.empty());
+        when(shipmentRepository.save(any(Shipment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        trackingService.initializeShipment(shipmentId, trackingId);
+
+        verify(shipmentRepository).save(any(Shipment.class));
+    }
+
+    @Test
+    @DisplayName("initializeShipment with duplicate shipmentId and same trackingId is idempotent")
+    void initializeShipment_duplicateWithSameTrackingId_ignored() {
+        UUID shipmentId = UUID.randomUUID();
+        String trackingId = "TRK-DUP";
+        Shipment existing = new Shipment(shipmentId, trackingId, ShipmentStatus.CREATED);
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(existing));
+
+        trackingService.initializeShipment(shipmentId, trackingId);
+
+        verify(shipmentRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("initializeShipment with existing shipmentId but different trackingId throws IllegalStateException")
+    void initializeShipment_existingIdDifferentTrackingId_throws() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment existing = new Shipment(shipmentId, "TRK-ORIGINAL", ShipmentStatus.CREATED);
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> trackingService.initializeShipment(shipmentId, "TRK-DIFFERENT"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already exists with trackingId")
+                .hasMessageContaining("TRK-ORIGINAL")
+                .hasMessageContaining("TRK-DIFFERENT");
+    }
+
+    @Test
+    @DisplayName("initializeShipment with trackingId already assigned to another shipment throws IllegalStateException")
+    void initializeShipment_trackingIdAlreadyUsed_throws() {
+        UUID newShipmentId = UUID.randomUUID();
+        UUID existingShipmentId = UUID.randomUUID();
+        String trackingId = "TRK-TAKEN";
+        Shipment existingByTracking = new Shipment(existingShipmentId, trackingId, ShipmentStatus.CREATED);
+
+        when(shipmentRepository.findById(newShipmentId)).thenReturn(Optional.empty());
+        when(shipmentRepository.findByTrackingId(trackingId)).thenReturn(Optional.of(existingByTracking));
+
+        assertThatThrownBy(() -> trackingService.initializeShipment(newShipmentId, trackingId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already assigned to shipment");
+    }
+
+    @Test
+    @DisplayName("initializeShipment DataIntegrityViolation with concurrent same shipment is idempotent")
+    void initializeShipment_dataIntegrityViolation_concurrentSameShipment_ignored() {
+        UUID shipmentId = UUID.randomUUID();
+        String trackingId = "TRK-CONCURRENT";
+
+        when(shipmentRepository.findById(shipmentId))
+                .thenReturn(Optional.empty())  // first call during initial check
+                .thenReturn(Optional.of(new Shipment(shipmentId, trackingId, ShipmentStatus.CREATED)));  // second call in catch block
+        when(shipmentRepository.findByTrackingId(trackingId)).thenReturn(Optional.empty());
+        when(shipmentRepository.save(any(Shipment.class)))
+                .thenThrow(new DataIntegrityViolationException("Duplicate key"));
+
+        trackingService.initializeShipment(shipmentId, trackingId);
+
+        verify(shipmentRepository).save(any(Shipment.class));
+    }
+
+    @Test
+    @DisplayName("initializeShipment DataIntegrityViolation with concurrent different shipment throws")
+    void initializeShipment_dataIntegrityViolation_conflicting_throws() {
+        UUID shipmentId = UUID.randomUUID();
+        String trackingId = "TRK-CONFLICT";
+
+        when(shipmentRepository.findById(shipmentId))
+                .thenReturn(Optional.empty())  // first call
+                .thenReturn(Optional.empty());  // second call in catch block - not found by id
+        when(shipmentRepository.findByTrackingId(trackingId))
+                .thenReturn(Optional.empty())  // first call
+                .thenReturn(Optional.empty());  // second call in catch block - not found by tracking either
+        when(shipmentRepository.save(any(Shipment.class)))
+                .thenThrow(new DataIntegrityViolationException("Duplicate key"));
+
+        assertThatThrownBy(() -> trackingService.initializeShipment(shipmentId, trackingId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Conflicting duplicate");
+    }
+
+    @Test
+    @DisplayName("initializeShipment DataIntegrityViolation with concurrent trackingId match is idempotent")
+    void initializeShipment_dataIntegrityViolation_concurrentByTrackingId_ignored() {
+        UUID shipmentId = UUID.randomUUID();
+        String trackingId = "TRK-TRACKING-CONCURRENT";
+
+        when(shipmentRepository.findById(shipmentId))
+                .thenReturn(Optional.empty())  // first call
+                .thenReturn(Optional.empty());  // second call in catch - not found by id
+        when(shipmentRepository.findByTrackingId(trackingId))
+                .thenReturn(Optional.empty())  // first call
+                .thenReturn(Optional.of(new Shipment(shipmentId, trackingId, ShipmentStatus.CREATED)));  // second call in catch block
+        when(shipmentRepository.save(any(Shipment.class)))
+                .thenThrow(new DataIntegrityViolationException("Duplicate key"));
+
+        trackingService.initializeShipment(shipmentId, trackingId);
+
+        verify(shipmentRepository).save(any(Shipment.class));
+    }
+
+    @Test
+    @DisplayName("registerEvent OUT_FOR_DELIVERY maps to OUT_FOR_DELIVERY status")
+    void registerEvent_OUT_FOR_DELIVERY_mapsToOUT_FOR_DELIVERY() {
+        UUID shipmentId = UUID.randomUUID();
+        Shipment shipment = new Shipment(shipmentId, "TRK-001", ShipmentStatus.IN_TRANSIT,
+                LocalDateTime.now(), LocalDateTime.now());
+        when(shipmentRepository.findById(shipmentId)).thenReturn(Optional.of(shipment));
+        when(eventRepository.save(any(TrackingEvent.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(shipmentRepository.save(any(Shipment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        TrackingEvent result = trackingService.registerEvent(shipmentId, "OUT_FOR_DELIVERY", "Local Hub", LocalDateTime.now());
+
+        assertThat(result.getStatusAfter()).isEqualTo(ShipmentStatus.OUT_FOR_DELIVERY);
+        assertThat(result.getStatusBefore()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/messaging/publisher/RabbitMQEventPublisherTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/messaging/publisher/RabbitMQEventPublisherTest.java
@@ -1,0 +1,75 @@
+package com.github.camiloperez77.trackingservice.infrastructure.messaging.publisher;
+
+import com.github.camiloperez77.trackingservice.domain.model.TrackingEventNotification;
+import com.github.camiloperez77.trackingservice.infrastructure.messaging.config.RabbitMQConfig;
+import com.github.camiloperez77.trackingservice.infrastructure.messaging.dto.TrackingEventRecordedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RabbitMQEventPublisherTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private RabbitMQEventPublisher publisher;
+
+    @Test
+    @DisplayName("publishTrackingEventRecorded sends to correct exchange and routing key")
+    void publishTrackingEventRecorded_shouldSendToCorrectExchangeAndRoutingKey() {
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime occurredAt = LocalDateTime.now();
+        TrackingEventNotification notification = new TrackingEventNotification(
+                shipmentId, "TRK-001", "DISPATCHED", "CREATED", "IN_TRANSIT", occurredAt
+        );
+
+        publisher.publishTrackingEventRecorded(notification);
+
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.LOGISTICS_EXCHANGE),
+                eq("tracking.event.recorded"),
+                org.mockito.ArgumentMatchers.any(TrackingEventRecordedEvent.class)
+        );
+    }
+
+    @Test
+    @DisplayName("publishTrackingEventRecorded message contains correct fields")
+    void publishTrackingEventRecorded_shouldContainCorrectFields() {
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime occurredAt = LocalDateTime.now();
+        TrackingEventNotification notification = new TrackingEventNotification(
+                shipmentId, "TRK-002", "DELIVERED", "OUT_FOR_DELIVERY", "DELIVERED", occurredAt
+        );
+
+        publisher.publishTrackingEventRecorded(notification);
+
+        ArgumentCaptor<TrackingEventRecordedEvent> captor = ArgumentCaptor.forClass(TrackingEventRecordedEvent.class);
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.LOGISTICS_EXCHANGE),
+                eq("tracking.event.recorded"),
+                captor.capture()
+        );
+
+        TrackingEventRecordedEvent event = captor.getValue();
+        assertThat(event.getShipmentId()).isEqualTo(shipmentId);
+        assertThat(event.getTrackingId()).isEqualTo("TRK-002");
+        assertThat(event.getEventType()).isEqualTo("DELIVERED");
+        assertThat(event.getPreviousStatus()).isEqualTo("OUT_FOR_DELIVERY");
+        assertThat(event.getNewStatus()).isEqualTo("DELIVERED");
+        assertThat(event.getOccurredAt()).isEqualTo(occurredAt);
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/adapter/ShipmentRepositoryAdapterTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/adapter/ShipmentRepositoryAdapterTest.java
@@ -1,0 +1,120 @@
+package com.github.camiloperez77.trackingservice.infrastructure.persistence.adapter;
+
+import com.github.camiloperez77.trackingservice.domain.model.Shipment;
+import com.github.camiloperez77.trackingservice.domain.model.ShipmentStatus;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.entity.ShipmentEntity;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.mapper.ShipmentMapper;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.repository.ShipmentJpaRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShipmentRepositoryAdapterTest {
+
+    @Mock
+    private ShipmentJpaRepository jpaRepository;
+
+    @Mock
+    private ShipmentMapper mapper;
+
+    @InjectMocks
+    private ShipmentRepositoryAdapter adapter;
+
+    private final UUID shipmentId = UUID.randomUUID();
+    private final String trackingId = "TRK-123456";
+    private final LocalDateTime now = LocalDateTime.of(2026, 4, 7, 10, 0, 0);
+
+    private Shipment buildDomainShipment() {
+        return new Shipment(shipmentId, trackingId, ShipmentStatus.CREATED, now, now);
+    }
+
+    private ShipmentEntity buildShipmentEntity() {
+        ShipmentEntity entity = new ShipmentEntity();
+        entity.setId(shipmentId);
+        entity.setTrackingId(trackingId);
+        entity.setStatus("CREATED");
+        entity.setCreatedAt(now);
+        entity.setUpdatedAt(now);
+        return entity;
+    }
+
+    @Test
+    void save_shouldMapDomainToEntityAndSaveAndMapBack() {
+        Shipment domain = buildDomainShipment();
+        ShipmentEntity entity = buildShipmentEntity();
+        ShipmentEntity savedEntity = buildShipmentEntity();
+        Shipment expectedResult = buildDomainShipment();
+
+        when(mapper.toEntity(domain)).thenReturn(entity);
+        when(jpaRepository.save(entity)).thenReturn(savedEntity);
+        when(mapper.toDomain(savedEntity)).thenReturn(expectedResult);
+
+        Shipment result = adapter.save(domain);
+
+        assertThat(result).isSameAs(expectedResult);
+        verify(mapper).toEntity(domain);
+        verify(jpaRepository).save(entity);
+        verify(mapper).toDomain(savedEntity);
+    }
+
+    @Test
+    void findById_shouldReturnMappedDomainWhenFound() {
+        ShipmentEntity entity = buildShipmentEntity();
+        Shipment expectedDomain = buildDomainShipment();
+
+        when(jpaRepository.findById(shipmentId)).thenReturn(Optional.of(entity));
+        when(mapper.toDomain(entity)).thenReturn(expectedDomain);
+
+        Optional<Shipment> result = adapter.findById(shipmentId);
+
+        assertThat(result).isPresent().containsSame(expectedDomain);
+        verify(jpaRepository).findById(shipmentId);
+        verify(mapper).toDomain(entity);
+    }
+
+    @Test
+    void findById_shouldReturnEmptyWhenNotFound() {
+        when(jpaRepository.findById(shipmentId)).thenReturn(Optional.empty());
+
+        Optional<Shipment> result = adapter.findById(shipmentId);
+
+        assertThat(result).isEmpty();
+        verify(jpaRepository).findById(shipmentId);
+    }
+
+    @Test
+    void findByTrackingId_shouldReturnMappedDomainWhenFound() {
+        ShipmentEntity entity = buildShipmentEntity();
+        Shipment expectedDomain = buildDomainShipment();
+
+        when(jpaRepository.findByTrackingId(trackingId)).thenReturn(Optional.of(entity));
+        when(mapper.toDomain(entity)).thenReturn(expectedDomain);
+
+        Optional<Shipment> result = adapter.findByTrackingId(trackingId);
+
+        assertThat(result).isPresent().containsSame(expectedDomain);
+        verify(jpaRepository).findByTrackingId(trackingId);
+        verify(mapper).toDomain(entity);
+    }
+
+    @Test
+    void findByTrackingId_shouldReturnEmptyWhenNotFound() {
+        when(jpaRepository.findByTrackingId(trackingId)).thenReturn(Optional.empty());
+
+        Optional<Shipment> result = adapter.findByTrackingId(trackingId);
+
+        assertThat(result).isEmpty();
+        verify(jpaRepository).findByTrackingId(trackingId);
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/adapter/TrackingEventRepositoryAdapterTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/adapter/TrackingEventRepositoryAdapterTest.java
@@ -1,0 +1,100 @@
+package com.github.camiloperez77.trackingservice.infrastructure.persistence.adapter;
+
+import com.github.camiloperez77.trackingservice.domain.model.ShipmentStatus;
+import com.github.camiloperez77.trackingservice.domain.model.TrackingEvent;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.entity.TrackingEventEntity;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.mapper.TrackingEventMapper;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.repository.TrackingEventJpaRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrackingEventRepositoryAdapterTest {
+
+    @Mock
+    private TrackingEventJpaRepository jpaRepository;
+
+    @Mock
+    private TrackingEventMapper mapper;
+
+    @InjectMocks
+    private TrackingEventRepositoryAdapter adapter;
+
+    private final UUID eventId = UUID.randomUUID();
+    private final UUID shipmentId = UUID.randomUUID();
+    private final LocalDateTime occurredAt = LocalDateTime.of(2026, 4, 7, 10, 0, 0);
+    private final LocalDateTime createdAt = LocalDateTime.of(2026, 4, 7, 10, 0, 1);
+
+    private TrackingEvent buildDomainEvent() {
+        return new TrackingEvent(
+                eventId, shipmentId, "STATUS_CHANGE",
+                ShipmentStatus.CREATED, ShipmentStatus.IN_TRANSIT,
+                "Bogota", occurredAt, createdAt
+        );
+    }
+
+    private TrackingEventEntity buildEntity() {
+        TrackingEventEntity entity = new TrackingEventEntity();
+        entity.setId(eventId);
+        entity.setShipmentId(shipmentId);
+        entity.setEventType("STATUS_CHANGE");
+        entity.setStatusBefore("CREATED");
+        entity.setStatusAfter("IN_TRANSIT");
+        entity.setLocation("Bogota");
+        entity.setOccurredAt(occurredAt);
+        entity.setCreatedAt(createdAt);
+        return entity;
+    }
+
+    @Test
+    void save_shouldMapDomainToEntityAndSaveAndMapBack() {
+        TrackingEvent domain = buildDomainEvent();
+        TrackingEventEntity entity = buildEntity();
+        TrackingEventEntity savedEntity = buildEntity();
+        TrackingEvent expectedResult = buildDomainEvent();
+
+        when(mapper.toEntity(domain)).thenReturn(entity);
+        when(jpaRepository.save(entity)).thenReturn(savedEntity);
+        when(mapper.toDomain(savedEntity)).thenReturn(expectedResult);
+
+        TrackingEvent result = adapter.save(domain);
+
+        assertThat(result).isSameAs(expectedResult);
+        verify(mapper).toEntity(domain);
+        verify(jpaRepository).save(entity);
+        verify(mapper).toDomain(savedEntity);
+    }
+
+    @Test
+    void findByShipmentIdOrderByOccurredAtAsc_shouldReturnMappedList() {
+        TrackingEventEntity entity1 = buildEntity();
+        TrackingEventEntity entity2 = buildEntity();
+        entity2.setId(UUID.randomUUID());
+
+        TrackingEvent domain1 = buildDomainEvent();
+        TrackingEvent domain2 = buildDomainEvent();
+
+        when(jpaRepository.findByShipmentIdOrderByOccurredAtAsc(shipmentId))
+                .thenReturn(List.of(entity1, entity2));
+        when(mapper.toDomain(entity1)).thenReturn(domain1);
+        when(mapper.toDomain(entity2)).thenReturn(domain2);
+
+        List<TrackingEvent> result = adapter.findByShipmentIdOrderByOccurredAtAsc(shipmentId);
+
+        assertThat(result).hasSize(2).containsExactly(domain1, domain2);
+        verify(jpaRepository).findByShipmentIdOrderByOccurredAtAsc(shipmentId);
+        verify(mapper).toDomain(entity1);
+        verify(mapper).toDomain(entity2);
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/mapper/ShipmentMapperTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/mapper/ShipmentMapperTest.java
@@ -1,0 +1,92 @@
+package com.github.camiloperez77.trackingservice.infrastructure.persistence.mapper;
+
+import com.github.camiloperez77.trackingservice.domain.model.Shipment;
+import com.github.camiloperez77.trackingservice.domain.model.ShipmentStatus;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.entity.ShipmentEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShipmentMapperTest {
+
+    private final ShipmentMapper mapper = new ShipmentMapper();
+
+    @Test
+    @DisplayName("toDomain maps all fields including status enum conversion")
+    void toDomain_shouldMapAllFields() {
+        UUID id = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.now().minusDays(1);
+        LocalDateTime updatedAt = LocalDateTime.now();
+
+        ShipmentEntity entity = new ShipmentEntity();
+        entity.setId(id);
+        entity.setTrackingId("TRK-100");
+        entity.setStatus("IN_TRANSIT");
+        entity.setCreatedAt(createdAt);
+        entity.setUpdatedAt(updatedAt);
+
+        Shipment domain = mapper.toDomain(entity);
+
+        assertThat(domain.getId()).isEqualTo(id);
+        assertThat(domain.getTrackingId()).isEqualTo("TRK-100");
+        assertThat(domain.getStatus()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+        assertThat(domain.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(domain.getUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    @DisplayName("toEntity maps all fields")
+    void toEntity_shouldMapAllFields() {
+        UUID id = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.now().minusDays(1);
+        LocalDateTime updatedAt = LocalDateTime.now();
+
+        Shipment domain = new Shipment(id, "TRK-200", ShipmentStatus.DELIVERED, createdAt, updatedAt);
+
+        ShipmentEntity entity = mapper.toEntity(domain);
+
+        assertThat(entity.getId()).isEqualTo(id);
+        assertThat(entity.getTrackingId()).isEqualTo("TRK-200");
+        assertThat(entity.getStatus()).isEqualTo("DELIVERED");
+        assertThat(entity.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(entity.getUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    @DisplayName("toDomain correctly converts each ShipmentStatus enum value")
+    void toDomain_shouldConvertAllStatusValues() {
+        ShipmentEntity entity = new ShipmentEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setTrackingId("TRK-300");
+        entity.setCreatedAt(LocalDateTime.now());
+        entity.setUpdatedAt(LocalDateTime.now());
+
+        for (ShipmentStatus status : ShipmentStatus.values()) {
+            entity.setStatus(status.name());
+            Shipment domain = mapper.toDomain(entity);
+            assertThat(domain.getStatus()).isEqualTo(status);
+        }
+    }
+
+    @Test
+    @DisplayName("Roundtrip: toDomain(toEntity(domain)) preserves data")
+    void roundtrip_shouldPreserveData() {
+        UUID id = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.now().minusDays(1);
+        LocalDateTime updatedAt = LocalDateTime.now();
+
+        Shipment original = new Shipment(id, "TRK-400", ShipmentStatus.EXCEPTION, createdAt, updatedAt);
+
+        Shipment result = mapper.toDomain(mapper.toEntity(original));
+
+        assertThat(result.getId()).isEqualTo(original.getId());
+        assertThat(result.getTrackingId()).isEqualTo(original.getTrackingId());
+        assertThat(result.getStatus()).isEqualTo(original.getStatus());
+        assertThat(result.getCreatedAt()).isEqualTo(original.getCreatedAt());
+        assertThat(result.getUpdatedAt()).isEqualTo(original.getUpdatedAt());
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/mapper/TrackingEventMapperTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/infrastructure/persistence/mapper/TrackingEventMapperTest.java
@@ -1,0 +1,157 @@
+package com.github.camiloperez77.trackingservice.infrastructure.persistence.mapper;
+
+import com.github.camiloperez77.trackingservice.domain.model.ShipmentStatus;
+import com.github.camiloperez77.trackingservice.domain.model.TrackingEvent;
+import com.github.camiloperez77.trackingservice.infrastructure.persistence.entity.TrackingEventEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TrackingEventMapperTest {
+
+    private final TrackingEventMapper mapper = new TrackingEventMapper();
+
+    @Test
+    @DisplayName("toDomain maps all fields")
+    void toDomain_shouldMapAllFields() {
+        UUID id = UUID.randomUUID();
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime occurredAt = LocalDateTime.now().minusHours(1);
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        TrackingEventEntity entity = new TrackingEventEntity();
+        entity.setId(id);
+        entity.setShipmentId(shipmentId);
+        entity.setEventType("DISPATCHED");
+        entity.setStatusBefore("CREATED");
+        entity.setStatusAfter("IN_TRANSIT");
+        entity.setLocation("Hub Central");
+        entity.setOccurredAt(occurredAt);
+        entity.setCreatedAt(createdAt);
+
+        TrackingEvent domain = mapper.toDomain(entity);
+
+        assertThat(domain.getId()).isEqualTo(id);
+        assertThat(domain.getShipmentId()).isEqualTo(shipmentId);
+        assertThat(domain.getEventType()).isEqualTo("DISPATCHED");
+        assertThat(domain.getStatusBefore()).isEqualTo(ShipmentStatus.CREATED);
+        assertThat(domain.getStatusAfter()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+        assertThat(domain.getLocation()).isEqualTo("Hub Central");
+        assertThat(domain.getOccurredAt()).isEqualTo(occurredAt);
+        assertThat(domain.getCreatedAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    @DisplayName("toEntity maps all fields")
+    void toEntity_shouldMapAllFields() {
+        UUID id = UUID.randomUUID();
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime occurredAt = LocalDateTime.now().minusHours(1);
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        TrackingEvent domain = new TrackingEvent(id, shipmentId, "DELIVERED",
+                ShipmentStatus.OUT_FOR_DELIVERY, ShipmentStatus.DELIVERED,
+                "Destination", occurredAt, createdAt);
+
+        TrackingEventEntity entity = mapper.toEntity(domain);
+
+        assertThat(entity.getId()).isEqualTo(id);
+        assertThat(entity.getShipmentId()).isEqualTo(shipmentId);
+        assertThat(entity.getEventType()).isEqualTo("DELIVERED");
+        assertThat(entity.getStatusBefore()).isEqualTo("OUT_FOR_DELIVERY");
+        assertThat(entity.getStatusAfter()).isEqualTo("DELIVERED");
+        assertThat(entity.getLocation()).isEqualTo("Destination");
+        assertThat(entity.getOccurredAt()).isEqualTo(occurredAt);
+        assertThat(entity.getCreatedAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    @DisplayName("toDomain handles null statusBefore")
+    void toDomain_nullStatusBefore_shouldMapToNull() {
+        TrackingEventEntity entity = new TrackingEventEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setShipmentId(UUID.randomUUID());
+        entity.setEventType("DISPATCHED");
+        entity.setStatusBefore(null);
+        entity.setStatusAfter("IN_TRANSIT");
+        entity.setLocation("Hub");
+        entity.setOccurredAt(LocalDateTime.now());
+        entity.setCreatedAt(LocalDateTime.now());
+
+        TrackingEvent domain = mapper.toDomain(entity);
+
+        assertThat(domain.getStatusBefore()).isNull();
+        assertThat(domain.getStatusAfter()).isEqualTo(ShipmentStatus.IN_TRANSIT);
+    }
+
+    @Test
+    @DisplayName("toDomain handles null statusAfter")
+    void toDomain_nullStatusAfter_shouldMapToNull() {
+        TrackingEventEntity entity = new TrackingEventEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setShipmentId(UUID.randomUUID());
+        entity.setEventType("UNKNOWN");
+        entity.setStatusBefore("CREATED");
+        entity.setStatusAfter(null);
+        entity.setLocation("Hub");
+        entity.setOccurredAt(LocalDateTime.now());
+        entity.setCreatedAt(LocalDateTime.now());
+
+        TrackingEvent domain = mapper.toDomain(entity);
+
+        assertThat(domain.getStatusBefore()).isEqualTo(ShipmentStatus.CREATED);
+        assertThat(domain.getStatusAfter()).isNull();
+    }
+
+    @Test
+    @DisplayName("toEntity handles null statusBefore")
+    void toEntity_nullStatusBefore_shouldMapToNull() {
+        TrackingEvent domain = new TrackingEvent(UUID.randomUUID(), UUID.randomUUID(), "DISPATCHED",
+                null, ShipmentStatus.IN_TRANSIT, "Hub", LocalDateTime.now(), LocalDateTime.now());
+
+        TrackingEventEntity entity = mapper.toEntity(domain);
+
+        assertThat(entity.getStatusBefore()).isNull();
+        assertThat(entity.getStatusAfter()).isEqualTo("IN_TRANSIT");
+    }
+
+    @Test
+    @DisplayName("toEntity handles null statusAfter")
+    void toEntity_nullStatusAfter_shouldMapToNull() {
+        TrackingEvent domain = new TrackingEvent(UUID.randomUUID(), UUID.randomUUID(), "UNKNOWN",
+                ShipmentStatus.CREATED, null, "Hub", LocalDateTime.now(), LocalDateTime.now());
+
+        TrackingEventEntity entity = mapper.toEntity(domain);
+
+        assertThat(entity.getStatusBefore()).isEqualTo("CREATED");
+        assertThat(entity.getStatusAfter()).isNull();
+    }
+
+    @Test
+    @DisplayName("Roundtrip: toDomain(toEntity(domain)) preserves data")
+    void roundtrip_shouldPreserveData() {
+        UUID id = UUID.randomUUID();
+        UUID shipmentId = UUID.randomUUID();
+        LocalDateTime occurredAt = LocalDateTime.now().minusHours(1);
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        TrackingEvent original = new TrackingEvent(id, shipmentId, "OUT_FOR_DELIVERY",
+                ShipmentStatus.IN_TRANSIT, ShipmentStatus.OUT_FOR_DELIVERY,
+                "Distribution Center", occurredAt, createdAt);
+
+        TrackingEvent result = mapper.toDomain(mapper.toEntity(original));
+
+        assertThat(result.getId()).isEqualTo(original.getId());
+        assertThat(result.getShipmentId()).isEqualTo(original.getShipmentId());
+        assertThat(result.getEventType()).isEqualTo(original.getEventType());
+        assertThat(result.getStatusBefore()).isEqualTo(original.getStatusBefore());
+        assertThat(result.getStatusAfter()).isEqualTo(original.getStatusAfter());
+        assertThat(result.getLocation()).isEqualTo(original.getLocation());
+        assertThat(result.getOccurredAt()).isEqualTo(original.getOccurredAt());
+        assertThat(result.getCreatedAt()).isEqualTo(original.getCreatedAt());
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/karate/TrackingKarateTest.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/karate/TrackingKarateTest.java
@@ -1,0 +1,20 @@
+package com.github.camiloperez77.trackingservice.karate;
+
+import com.intuit.karate.junit5.Karate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class TrackingKarateTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Karate.Test
+    Karate testTracking() {
+        return Karate.run("classpath:karate/tracking/tracking.feature")
+                .systemProperty("local.server.port", String.valueOf(port));
+    }
+}

--- a/src/test/java/com/github/camiloperez77/trackingservice/trackingserviceApplicationTests.java
+++ b/src/test/java/com/github/camiloperez77/trackingservice/trackingserviceApplicationTests.java
@@ -2,8 +2,10 @@ package com.github.camiloperez77.trackingservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class trackingserviceApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.flyway.enabled=false
+spring.rabbitmq.listener.simple.auto-startup=false
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672

--- a/src/test/resources/karate-config.js
+++ b/src/test/resources/karate-config.js
@@ -1,0 +1,7 @@
+function fn() {
+  var port = karate.properties['local.server.port'] || '8080';
+  var config = {
+    baseUrl: 'http://localhost:' + port
+  };
+  return config;
+}

--- a/src/test/resources/karate/tracking/tracking.feature
+++ b/src/test/resources/karate/tracking/tracking.feature
@@ -1,0 +1,19 @@
+Feature: Tracking Service API
+
+  Background:
+    * url baseUrl
+
+  Scenario: Get tracking history returns empty list for non-existent shipment
+    * def shipmentId = java.util.UUID.randomUUID().toString()
+    Given path '/api/v1/tracking/' + shipmentId + '/history'
+    When method GET
+    Then status 200
+    And match response == '#[]'
+    And match response == []
+
+  Scenario: Get current status returns 404 for non-existent shipment
+    * def shipmentId = java.util.UUID.randomUUID().toString()
+    Given path '/api/v1/tracking/' + shipmentId + '/current'
+    When method GET
+    Then status 404
+    And match response.code == 'NOT_FOUND'


### PR DESCRIPTION
…ate) for tracking-service

- 80 tests total: 78 unit/controller tests + 2 Karate API tests
- Coverage: Instructions 99.3%, Lines 98.7%, Methods 98.5%, Branches 93.5%
- JaCoCo plugin configured for coverage reports
- Tests cover: TrackingService (including idempotency and state transitions), ShipmentStatus state machine (18 transition tests), TrackingController, GlobalExceptionHandler, ShipmentCreatedListener, TrackingEventRequestListener, RabbitMQEventPublisher, repository adapters, and all mappers
- Karate features: tracking API endpoints (from SQA plan CP-04-01 to CP-04-03)
- H2 test config and @ActiveProfiles("test") added